### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/trocotech/1e2766a4-4a6b-46eb-a89d-d3fb7611a76a/054cd160-be3e-4d83-899f-7ccb6f18ac8a/_apis/work/boardbadge/af8ae926-11b2-410b-9ce5-46ee4c720928)](https://dev.azure.com/trocotech/1e2766a4-4a6b-46eb-a89d-d3fb7611a76a/_boards/board/t/054cd160-be3e-4d83-899f-7ccb6f18ac8a/Microsoft.RequirementCategory)
 # training
 trainingstuff


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#71](https://dev.azure.com/trocotech/1e2766a4-4a6b-46eb-a89d-d3fb7611a76a/_workitems/edit/71). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.